### PR TITLE
Remove Linux font fixes

### DIFF
--- a/resource/clientscheme.res
+++ b/resource/clientscheme.res
@@ -782,7 +782,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"tall_lodef"	"80"
 				"weight"	"500"
@@ -793,7 +792,6 @@ Scheme
 			"2"
 			{
 				"name"		"TF2"
-				"tall"		"31"	[$LINUX]
 				"tall"		"32"
 				"tall_hidef"	"120"
 				"weight"	"500"
@@ -804,7 +802,6 @@ Scheme
 			"3"
 			{
 				"name"		"TF2"
-				"tall"		"43"	[$LINUX]
 				"tall"		"44"
 				"weight"	"500"
 				"additive"	"0"
@@ -814,7 +811,6 @@ Scheme
 			"4"
 			{
 				"name"		"TF2"
-				"tall"		"47"	[$LINUX]
 				"tall"		"48"
 				"weight"	"500"
 				"additive"	"0"
@@ -824,7 +820,6 @@ Scheme
 			"5"
 			{
 				"name"		"TF2"
-				"tall"		"51"	[$LINUX]
 				"tall"		"52"
 				"weight"	"500"
 				"additive"	"0"
@@ -837,7 +832,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"43"	[$LINUX]
 				"tall"		"44"
 				"tall_lodef"	"52"
 				"weight"	"500"
@@ -851,7 +845,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"34"	[$LINUX]
 				"tall"		"35"
 				"tall_lodef"	"40"
 				"weight"	"500"
@@ -865,7 +858,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"35"	[$LINUX]
 				"tall"		"36"
 				"tall_hidef"	"48"
 				"weight"	"500"
@@ -878,7 +870,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"29"	[$LINUX]
 				"tall"		"30"
 				"weight"	"500"
 				"additive"	"0"
@@ -890,7 +881,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"29"	[$LINUX]
 				"tall"		"30"
 				"weight"	"500"
 				"additive"	"0"
@@ -902,7 +892,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"tall_lodef"		"28"
 				"weight"	"500"
@@ -915,7 +904,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"500"
 				"additive"	"0"
@@ -927,7 +915,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"500"
 				"additive"	"0"
@@ -939,7 +926,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"500"
 				"additive"	"0"
@@ -951,7 +937,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"tall_hidef"	"24"
 				"tall_lodef"	"18"
@@ -965,7 +950,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"tall_hidef"	"24"
 				"tall_lodef"	"20"
@@ -979,7 +963,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"13"	[$LINUX]
 				"tall"		"14"
 				"tall_lodef"	"16"
 				"weight"	"500"
@@ -992,7 +975,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"15"	[$LINUX]
 				"tall"		"16"
 				"weight"	"500"
 				"additive"	"0"
@@ -1004,7 +986,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"13"	[$LINUX]
 				"tall"		"14"
 				"weight"	"500"
 				"additive"	"0"
@@ -1016,7 +997,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"13"	[$LINUX]
 				"tall"		"14"
 				"weight"	"500"
 				"additive"	"0"
@@ -1063,7 +1043,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"14"	[$LINUX]
 				"tall"		"15"
 				"weight"	"500"
 				"additive"	"0"
@@ -1097,7 +1076,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"15"	[$LINUX]
 				"tall"		"16"
 				"weight"	"500"
 				"additive"	"0"
@@ -1230,7 +1208,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"tall_hidef"	"24"
 				"tall_lodef"	"18"
@@ -1244,7 +1221,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"15"	[$LINUX]
 				"tall"		"16"
 				"tall_hidef"	"22"
 				"tall_lodef"	"22"
@@ -1305,7 +1281,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"14"	[$LINUX]
 				"tall"		"15"
 				"weight"	"700"
 				"antialias" 	"1"
@@ -1316,7 +1291,6 @@ Scheme
 			"2"
 			{
 				"name"		"TF2"
-				"tall"		"14"	[$LINUX]
 				"tall"		"15"	[$WIN32]
 				"tall"		"21"	[$X360]
 				"weight"	"700"
@@ -1328,7 +1302,6 @@ Scheme
 			"3"
 			{
 				"name"		"TF2"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"900"
 				"antialias" 	"1"
@@ -1338,7 +1311,6 @@ Scheme
 			"4"
 			{
 				"name"		"TF2"
-				"tall"		"20"	[$LINUX]
 				"tall"		"21"
 				"weight"	"900"
 				"antialias" 	"1"
@@ -1348,7 +1320,6 @@ Scheme
 			"5"
 			{
 				"name"		"TF2"
-				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"1000"
 				"antialias" 	"1"
@@ -1415,7 +1386,6 @@ Scheme
 			"1"
 			{
 				"name"  "Team Fortress" // tf.ttf
-				"tall"	"27"	[$LINUX]
 				"tall"  "28"
 				"weight" "0"
 				"additive" "1"
@@ -1516,7 +1486,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"antialias" "1"
 				"weight"	"500"
@@ -1563,7 +1532,6 @@ Scheme
 			"1"
 			{
 				"name"			"TF2 Professor"
-				"tall"			"27"	[$LINUX]
 				"tall"			"28"
 				"tall_lodef"	"48"
 				"tall_hidef"	"48"
@@ -1579,7 +1547,6 @@ Scheme
 			"1"
 			{
 				"name"			"TF2 Professor"
-				"tall"			"39"	[$LINUX]
 				"tall"			"40"
 				"tall_lodef"	"48"
 				"tall_hidef"	"48"
@@ -1595,7 +1562,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Professor"
-				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"tall_lodef"	"36"
 				"tall_hidef"	"36"
@@ -1672,7 +1638,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"weight"	"500"
 				"range"		"0x0000 0x007F"	//	Basic Latin
@@ -1685,7 +1650,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"tall_hidef"	"24"
 				"tall_lodef"	"24"
@@ -1712,7 +1676,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"weight"	"500"
 				"range"		"0x0000 0x007F"	//	Basic Latin
@@ -1725,7 +1688,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"33"	[$LINUX]
 				"tall"		"34"
 				"tall_hidef"	"38"
 				"tall_lodef"	"38"
@@ -1741,7 +1703,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"35"	[$LINUX]
 				"tall"		"36"
 				"tall_hidef"	"48"
 				"weight"	"500"
@@ -1754,7 +1715,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"51"	[$LINUX]
 				"tall"		"52"
 				"tall_lodef"		"80"
 				"range" 	"0x0000 0x00FF"
@@ -1765,7 +1725,6 @@ Scheme
 			"2"
 			{
 				"name"		"TF2"
-				"tall"		"71"	[$LINUX]
 				"tall"		"72"
 				"tall_hidef"	"120"
 				"range" 	"0x0000 0x00FF"
@@ -1776,7 +1735,6 @@ Scheme
 			"3"
 			{
 				"name"		"TF2"
-				"tall"		"99"	[$LINUX]
 				"tall"		"100"
 				"range" 	"0x0000 0x00FF"
 				"weight"	"400"
@@ -1786,7 +1744,6 @@ Scheme
 			"4"
 			{
 				"name"		"TF2"
-				"tall"		"139"	[$LINUX]
 				"tall"		"140"
 				"range" 	"0x0000 0x00FF"
 				"weight"	"400"
@@ -1796,7 +1753,6 @@ Scheme
 			"5"
 			{
 				"name"		"TF2"
-				"tall"		"179"	[$LINUX]
 				"tall"		"180"
 				"range" 	"0x0000 0x00FF"
 				"weight"	"400"
@@ -1809,7 +1765,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"35"	[$LINUX]
 				"tall"		"36"
 				"weight"	"500"
 				"range"		"0x0000 0x007F"	//	Basic Latin
@@ -1833,7 +1788,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"weight"	"400"
 				"additive"	"0"
@@ -1960,7 +1914,6 @@ Scheme
 			"4"
 			{
 				"name"		"Verdana"
-				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"weight"	"700"
 				"yres"		"1024 1199"
@@ -1969,7 +1922,6 @@ Scheme
 			"5"
 			{
 				"name"		"Verdana"
-				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"700"
 				"yres"		"1200 10000"
@@ -2116,7 +2068,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"35"	[$LINUX]
 				"tall"		"36"
 				"tall_lodef"		"28"
 				"weight"	"500"
@@ -2127,7 +2078,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"29"	[$LINUX]
 				"tall"		"30"
 				"tall_lodef"		"22"
 				"weight"	"500"
@@ -2138,7 +2088,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"27"	[$LINUX]
 				"tall"		"28"
 				"tall_lodef"	"24"
 				"weight"	"500"
@@ -2167,7 +2116,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"21"	[$LINUX]
 				"tall"		"22"
 				"weight"	"500"
 			}
@@ -2177,7 +2125,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"500"
 			}
@@ -2217,7 +2164,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"35"	[$LINUX]
 				"tall"		"36"
 				"weight"	"500"
 				"additive"	"0"
@@ -2240,7 +2186,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"400"
 				"additive"	"0"
@@ -2360,7 +2305,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"500"
 				"additive"	"0"
@@ -2372,7 +2316,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"6"	[$LINUX]
 				"tall"		"7"
 				"weight"	"500"
 				"additive"	"0"
@@ -2394,7 +2337,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"7"	[$LINUX]
 				"tall"		"8"
 				"weight"	"500"
 				"additive"	"0"
@@ -2591,7 +2533,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Professor"
-				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"antialias" "1"
 				"custom"		"1" [$OSX]
@@ -2622,7 +2563,6 @@ Scheme
 			"3"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"21"	[$LINUX]
 				"tall"		"22"
 				"weight"	"400"
 				"additive"	"0"
@@ -2656,7 +2596,6 @@ Scheme
 			"3"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"21"	[$LINUX]
 				"tall"		"22"
 				"weight"	"400"
 				"additive"	"0"
@@ -2689,7 +2628,6 @@ Scheme
 			"3"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"800"
 				"additive"	"0"
@@ -2715,7 +2653,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"15"	[$LINUX]
 				"tall"		"16"
 				"weight"	"400"
 				"additive"	"0"
@@ -2922,7 +2859,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"tall_hidef"	"24"
 				"tall_lodef"	"18"
@@ -2936,7 +2872,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"500"
 				"additive"	"0"
@@ -2948,7 +2883,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
-				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"tall_hidef"	"24"
 				"tall_lodef"	"20"
@@ -2977,7 +2911,6 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
-				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"500"
 				"additive"	"0"


### PR DESCRIPTION
As far as I can tell these changes haven't been necessary since the 64-bit update