### PR TITLE
Fixed oversized rank model on match summary screen

### DIFF
--- a/resource/ui/pvprankpanel.res
+++ b/resource/ui/pvprankpanel.res
@@ -53,12 +53,12 @@
 			"ypos"			"cs-0.5+2"
 			"zpos"			"0"		
 			"wide"			"o1"
-			"tall"			"62"
+			"tall"			"p0.12"
 			"autoResize"	"0"
 			"pinCorner"		"0"
 			"visible"		"1"
 			"enabled"		"1"
-			"fov"			"45"
+			"fov"			"70"
 			"proportionaltoparent"	"1"
 
 			if_mini


### PR DESCRIPTION
Seems to have been caused by https://github.com/CriticalFlaw/TF2HUD-Fixes/commit/8c32405e9e6c2188d9eb0e0e298a4ea9a5c3e2bf? 

**Before:**
![prefix](https://github.com/user-attachments/assets/327f92ea-382c-493e-a352-671f72b66347)

**After:**
![fix](https://github.com/user-attachments/assets/edb5e0d4-565f-4954-a4f4-aa243170849d)

