### PR TITLE
Fixed rank model being too small on Competitive match summary screen

### DIFF
--- a/resource/ui/pvpcomprankpanel.res
+++ b/resource/ui/pvpcomprankpanel.res
@@ -1,0 +1,96 @@
+#base "PvPRankPanel.res"
+
+"Resource/UI/PvPRankPanel.res"
+{
+	"ModelContainer"
+	{
+		"RankModel"
+		{
+			if_mini
+			{
+				"xpos"		"cs-0.5-120"
+				"fov"		"45"
+			}
+		}
+
+		"MedalButton"
+		{
+			"ypos"			"cs-0.5-10"
+			"wide"			"75"
+			"tall"			"85"
+		}
+	}
+
+	"BGPanel"
+	{
+		if_mini
+		{
+			"wide"			"270"
+			"tall"			"60"
+		}
+
+		"PlacementLabel"
+		{
+			if_mini
+			{
+				"ypos"			"17"
+			}
+		}
+
+		"DescLine1"
+		{
+			if_mini
+			{
+				"xpos"			"cs-0.5"
+				"ypos"			"35"
+
+				"textAlignment"	"center"
+
+				"fonts"
+				{
+					"0"		"HudFontSmallBold"
+					"1"		"StorePromotionsTitle"
+					"2"		"FontStorePrice"
+				}
+			}
+		}
+
+		"StatsContainer"
+		{
+			"visible"		"1"
+
+			if_mini
+			{
+				"xpos"	"cs-0.5"
+				"ypos"	"25"
+			}
+
+			"XPBar"
+			{
+				"ypos"	"20"
+				"alpha"	"100"
+
+				"CurrentXPLabel"
+				{
+					"visible"		"1"
+
+					if_mini
+					{
+						"xpos"			"cs-0.5"
+						"textAlignment"	"center"
+					}
+				}
+
+				"NextLevelXPLabel"
+				{
+					"visible"		"0"
+				}
+
+				"ProgressBarsContainer"
+				{
+					"visible"		"0"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This _potentially_ fixes #298. 

All I did was add `"fov" "45"` under if_mini of the RankModel in pvpcomprankpanel, which theoretically should work.