### PR TITLE
Fixed oversized center text

### DIFF
--- a/resource/sourceschemebase.res
+++ b/resource/sourceschemebase.res
@@ -518,6 +518,19 @@ Scheme
 				"name"		"Trebuchet MS"
 				"tall"		"24"
 				"weight"	"900"
+				"range"		"0x0000 0x007F"    //    Basic Latin
+				"antialias"	"1"
+ 				"additive"	"1"
+				"yres"		"480 1199"
+			}
+			"2" // misyl: Proportional
+			{
+				"name"			"Trebuchet MS"
+				"tall"			"16"
+				"weight"		"900"
+				"range"			"0x0000 0x007F"    //    Basic Latin
+				"antialias"		"1"
+				"additive"		"1"
 			}
 		}
 


### PR DESCRIPTION
This just makes it how it was before.

Before:
![20250522140443_1](https://github.com/user-attachments/assets/368f7d30-426e-4abb-b128-7cd517db3d65)

After:
![20250522140826_1](https://github.com/user-attachments/assets/a9721453-467f-4754-b08a-21e7157433cf)
